### PR TITLE
Modifications to work RET model training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ mc_logits
 train-*
 logs/
 fib_logits
-checkpoints/
+checkpoint/*
+!checkpoint/.keep
 videocap/checkpoint/*
 tags
 coco

--- a/videocap/configuration.py
+++ b/videocap/configuration.py
@@ -53,7 +53,7 @@ class TrainConfig(object):
 
         self.steps_per_logging = 500
         self.steps_per_evaluate = 5000
-        self.train_tag = 'FIB'
+        self.train_tag = 'RET'
 
         self.load_from_ckpt = None
         self.print_evaluate = False

--- a/videocap/datasets/lsmdc.py
+++ b/videocap/datasets/lsmdc.py
@@ -115,6 +115,7 @@ class DatasetLSMDC():
         train_cap_df = pd.read_csv(train_cap_path, sep='\t')
         val_cap_df = pd.read_csv(val_cap_path, sep='\t')
         test_cap_df = pd.read_csv(test_cap_path, sep='\t')
+        par_cap_df = pd.read_csv(par_cap_path, sep='\t')
         if self.dataset_name == 'train':
             if self.data_type in ['MC']:
                 train_data_path = train_cap_path
@@ -125,6 +126,8 @@ class DatasetLSMDC():
                     data_df = pd.concat([data_df,val_fib_df])
                 if self.data_type in ['MC','CAP']:
                     val_cap_df = pd.read_csv(val_cap_path, sep='\t')
+                if self.data_type == 'RET':
+                    data_df = pd.concat([data_df, val_cap_df, par_cap_df])
         elif self.dataset_name == 'validation':
             data_df = pd.read_csv(val_data_path, sep='\t')
         elif self.dataset_name == 'test':

--- a/videocap/datasets/lsmdc.py
+++ b/videocap/datasets/lsmdc.py
@@ -117,7 +117,7 @@ class DatasetLSMDC():
         test_cap_df = pd.read_csv(test_cap_path, sep='\t')
         par_cap_df = pd.read_csv(par_cap_path, sep='\t')
         if self.dataset_name == 'train':
-            if self.data_type in ['MC']:
+            if self.data_type in ['MC', 'RET']:
                 train_data_path = train_cap_path
             data_df = pd.read_csv(train_data_path, sep='\t')
             if self.more_data == True:

--- a/videocap/models/ret_model.py
+++ b/videocap/models/ret_model.py
@@ -425,3 +425,6 @@ class RETTrainer(object):
             len(c10),medr = medr))
         log.infov("[RET] total accuracy: {acc:.5f}".format(acc=np.sum(acc)))
 
+        if generate_results:
+            with open('./checkpoint/evaluate_log.tsv', 'a') as f:
+                f.write('[{}]\t{}\t{}\t{}\t{}\t{}\n'.format(global_step, len(c), len(c5), len(c10), medr, np.sum(acc)))

--- a/videocap/train.py
+++ b/videocap/train.py
@@ -1,5 +1,8 @@
-import time
 import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+import time
 import pprint
 import tensorflow as tf
 from videocap.datasets.lsmdc import DatasetLSMDC
@@ -19,6 +22,7 @@ from tqdm import tqdm
 import hickle as hkl
 import numpy as np
 
+os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'
 pp = pprint.PrettyPrinter(indent=2)
 
 tf.flags.DEFINE_string("tag","","Tag for test")
@@ -114,7 +118,7 @@ def main(argv):
                 trainer.log_step_message(**step_result)
 
             if step_result['current_step'] % train_config.steps_per_evaluate == 0 or train_config.print_evaluate:
-                trainer.evaluate(queue=val_queue, dataset=validation_dataset, generate_results=True, tag=FLAGS.tag)
+                trainer.evaluate(queue=val_queue, dataset=validation_dataset, global_step=step, generate_results=True, tag=FLAGS.tag)
 
                 print("SAVE MODEL"+FLAGS.tag)
                 saver.save(session, checkpoint_dir, global_step=step)


### PR DESCRIPTION
I modified codes to train RET model.

Now, we can start training with the following command.
```
python videocap/train.py --tag RET
```
Note: 2.5 days will be taken to train it over 400K steps.

@yj-yu Could you confirm whether this modification is correct to reproduce your reported results?